### PR TITLE
Add polygon labels, change some constants and fix bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
   <script type="text/javascript" src="google-doc-url.js"></script>
   <script type="text/javascript" src="scripts/constants.js"></script>
   <script type="text/javascript" src="scripts/palette.js"></script>
+  <script type="text/javascript" src="scripts/polylabel.js"></script>
   <script type="text/javascript" src="scripts/map.js"></script>
 
 </body>

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,13 +1,10 @@
 var constants = {
-  // Sheets or Tabs
+  // Tabs in Google Sheet
   notesSheetName: 'Notes',
 	optionsSheetName: 'Options',
 	pointsSheetName: 'Points',
   polygonsSheetName: 'Polygons',
-  // Columns2
-  polygonsProp: 'Polygon GeoJSON Property',
-  polygonsPropName: 'Display Label',
-  // Options
+  /* OPTIONS */
 	// Map Info
   _pageTitle: 'Page Title',
   _subtitle: 'Subtitle',
@@ -33,20 +30,20 @@ var constants = {
 	_locateControlPos: 'Show My Location',
 	_attrPos: 'Credits and Attribution',
 	// Point Map Display
-	_pointsTitle: 'Point Layer Legend Title',
-	_layersPos: 'Point Layer Legend Position',
+	_pointsTitle: 'Point Legend Title',
+	_layersPos: 'Point Legend Position',
 	// Polygon Map Display
 	_legendTitle: 'Polygon Legend Title',
 	_legendPosition: 'Polygon Legend Position',
   _geojsonURL: 'Polygon GeoJSON URL',
-  //_bucketProp: 'GeoJSON Properties',
-  _popupProp: 'GeoJSON Popup Properties',
-  _polygonLayers: 'GeoJSON Layers',
-  //_bucketPropName: 'Property Labels in Legend',
-  _bucketDivisors: 'Property Range Dividers',
+  _popupProp: 'Property Popups, Labels',
+  _polygonLayers: 'Polygon Properties, Labels',
+  _bucketDivisors: 'Property Ranges',
 	_colorScheme: 'Property Range Color Palette',
   _colorOpacity: 'Polygon Color Opacity',
   _outlineColor: 'Polygon Outline Color',
   _bucketColors: 'Property Range Manual Colors',
   _polygonDisplayImages: 'Display Images When Available',
+  _polygonLabel: 'Display Polygon Label',
+  _polygonLabelMaxZoom: 'Maximum Zoom for Polygon Label'
 };

--- a/scripts/polylabel.js
+++ b/scripts/polylabel.js
@@ -1,0 +1,226 @@
+function TinyQueue(data, compare) {
+    if (!(this instanceof TinyQueue)) return new TinyQueue(data, compare);
+
+    this.data = data || [];
+    this.length = this.data.length;
+    this.compare = compare || defaultCompare;
+
+    if (data) for (var i = Math.floor(this.length / 2); i >= 0; i--) this._down(i);
+}
+
+function defaultCompare(a, b) {
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+
+TinyQueue.prototype = {
+
+    push: function (item) {
+        this.data.push(item);
+        this.length++;
+        this._up(this.length - 1);
+    },
+
+    pop: function () {
+        var top = this.data[0];
+        this.data[0] = this.data[this.length - 1];
+        this.length--;
+        this.data.pop();
+        this._down(0);
+        return top;
+    },
+
+    peek: function () {
+        return this.data[0];
+    },
+
+    _up: function (pos) {
+        var data = this.data,
+            compare = this.compare;
+
+        while (pos > 0) {
+            var parent = Math.floor((pos - 1) / 2);
+            if (compare(data[pos], data[parent]) < 0) {
+                swap(data, parent, pos);
+                pos = parent;
+
+            } else break;
+        }
+    },
+
+    _down: function (pos) {
+        var data = this.data,
+            compare = this.compare,
+            len = this.length;
+
+        while (true) {
+            var left = 2 * pos + 1,
+                right = left + 1,
+                min = pos;
+
+            if (left < len && compare(data[left], data[min]) < 0) min = left;
+            if (right < len && compare(data[right], data[min]) < 0) min = right;
+
+            if (min === pos) return;
+
+            swap(data, min, pos);
+            pos = min;
+        }
+    }
+};
+
+function swap(data, i, j) {
+    var tmp = data[i];
+    data[i] = data[j];
+    data[j] = tmp;
+}
+
+
+function polylabel(polygon, precision, debug) {
+    precision = precision || 1.0;
+
+    // find the bounding box of the outer ring
+    var minX, minY, maxX, maxY;
+    for (var i = 0; i < polygon[0].length; i++) {
+        var p = polygon[0][i];
+        if (!i || p[0] < minX) minX = p[0];
+        if (!i || p[1] < minY) minY = p[1];
+        if (!i || p[0] > maxX) maxX = p[0];
+        if (!i || p[1] > maxY) maxY = p[1];
+    }
+
+    var width = maxX - minX;
+    var height = maxY - minY;
+    var cellSize = Math.min(width, height);
+    var h = cellSize / 2;
+
+    // a priority queue of cells in order of their "potential" (max distance to polygon)
+    var cellQueue = new TinyQueue(null, compareMax);
+
+    if (cellSize === 0) return [minX, minY];
+
+    // cover polygon with initial cells
+    for (var x = minX; x < maxX; x += cellSize) {
+        for (var y = minY; y < maxY; y += cellSize) {
+            cellQueue.push(new Cell(x + h, y + h, h, polygon));
+        }
+    }
+
+    // take centroid as the first best guess
+    var bestCell = getCentroidCell(polygon);
+
+    // special case for rectangular polygons
+    var bboxCell = new Cell(minX + width / 2, minY + height / 2, 0, polygon);
+    if (bboxCell.d > bestCell.d) bestCell = bboxCell;
+
+    var numProbes = cellQueue.length;
+
+    while (cellQueue.length) {
+        // pick the most promising cell from the queue
+        var cell = cellQueue.pop();
+
+        // update the best cell if we found a better one
+        if (cell.d > bestCell.d) {
+            bestCell = cell;
+            if (debug) console.log('found best %d after %d probes', Math.round(1e4 * cell.d) / 1e4, numProbes);
+        }
+
+        // do not drill down further if there's no chance of a better solution
+        if (cell.max - bestCell.d <= precision) continue;
+
+        // split the cell into four cells
+        h = cell.h / 2;
+        cellQueue.push(new Cell(cell.x - h, cell.y - h, h, polygon));
+        cellQueue.push(new Cell(cell.x + h, cell.y - h, h, polygon));
+        cellQueue.push(new Cell(cell.x - h, cell.y + h, h, polygon));
+        cellQueue.push(new Cell(cell.x + h, cell.y + h, h, polygon));
+        numProbes += 4;
+    }
+
+    if (debug) {
+        console.log('num probes: ' + numProbes);
+        console.log('best distance: ' + bestCell.d);
+    }
+
+    return [bestCell.x, bestCell.y];
+}
+
+function compareMax(a, b) {
+    return b.max - a.max;
+}
+
+function Cell(x, y, h, polygon) {
+    this.x = x; // cell center x
+    this.y = y; // cell center y
+    this.h = h; // half the cell size
+    this.d = pointToPolygonDist(x, y, polygon); // distance from cell center to polygon
+    this.max = this.d + this.h * Math.SQRT2; // max distance to polygon within a cell
+}
+
+// signed distance from point to polygon outline (negative if point is outside)
+function pointToPolygonDist(x, y, polygon) {
+    var inside = false;
+    var minDistSq = Infinity;
+
+    for (var k = 0; k < polygon.length; k++) {
+        var ring = polygon[k];
+
+        for (var i = 0, len = ring.length, j = len - 1; i < len; j = i++) {
+            var a = ring[i];
+            var b = ring[j];
+
+            if ((a[1] > y !== b[1] > y) &&
+                (x < (b[0] - a[0]) * (y - a[1]) / (b[1] - a[1]) + a[0])) inside = !inside;
+
+            minDistSq = Math.min(minDistSq, getSegDistSq(x, y, a, b));
+        }
+    }
+
+    return (inside ? 1 : -1) * Math.sqrt(minDistSq);
+}
+
+// get polygon centroid
+function getCentroidCell(polygon) {
+    var area = 0;
+    var x = 0;
+    var y = 0;
+    var points = polygon[0];
+
+    for (var i = 0, len = points.length, j = len - 1; i < len; j = i++) {
+        var a = points[i];
+        var b = points[j];
+        var f = a[0] * b[1] - b[0] * a[1];
+        x += (a[0] + b[0]) * f;
+        y += (a[1] + b[1]) * f;
+        area += f * 3;
+    }
+    if (area === 0) return new Cell(points[0][0], points[0][1], 0, polygon);
+    return new Cell(x / area, y / area, 0, polygon);
+}
+
+// get squared distance from a point to a segment
+function getSegDistSq(px, py, a, b) {
+
+    var x = a[0];
+    var y = a[1];
+    var dx = b[0] - x;
+    var dy = b[1] - y;
+
+    if (dx !== 0 || dy !== 0) {
+
+        var t = ((px - x) * dx + (py - y) * dy) / (dx * dx + dy * dy);
+
+        if (t > 1) {
+            x = b[0];
+            y = b[1];
+
+        } else if (t > 0) {
+            x += dx * t;
+            y += dy * t;
+        }
+    }
+
+    dx = px - x;
+    dy = py - y;
+
+    return dx * dx + dy * dy;
+}

--- a/style.css
+++ b/style.css
@@ -187,3 +187,12 @@ h3 {
   text-align: center;
   border-radius: 5px;
 }
+
+.polygon-label {
+  color: #444;
+  font-weight: bold;
+  opacity: 0.9;
+  position: absolute;
+  left: -15px;
+  pointer-events: none !important;
+}


### PR DESCRIPTION
* Some labels in Google Sheet changed to the ones specified in #55
* Added support for polygon labels (#54). Two fields in Google Sheet: a GeoJSON property, value of which will be displayed (currently 'name' = name of the town) and zoom at which labels will disappear (has to be hand-picked, default is 9 – works well for the current map). This is not panes feature in Leaflet (panes are given by basemap providers, whereas we need to extract properties from GeoJSON and put them in the middle of a polygon). I used this library https://github.com/mapbox/polylabel to deal with geometry and figure out the 'center' where we put the label – this is way more complicated than simply finding the average of NW and SE coordinates, since most polygons are **not convex**. Results are not perfect, but it's as good as we can get. Idea borrowed from here: http://stackoverflow.com/questions/22796520/finding-the-center-of-leaflet-polygon 
* `polylabels.js` contains two libraries: Polylabel + TinyQueue (https://github.com/mourner/tinyqueue needed for polylabel to work)
* Fixed a bug: before when polygon label was 'Off' and you click on the title to minimize the legend, radio buttons disappeared but color box appeared – now 'Off' is toggled as desired
* Minor code changes and improvements